### PR TITLE
Added color group classification

### DIFF
--- a/components/UserAdminView.tsx
+++ b/components/UserAdminView.tsx
@@ -19,6 +19,7 @@ interface UserProfile extends Omit<Registration, 'user'> {
     lastName: string;
     permissions: string[];
     preferredEmail: string;
+    color: string;
   };
 }
 
@@ -163,6 +164,10 @@ export default function UserAdminView({
             <h1 className="font-bold text-center">
               {currentUser.user.firstName + ' ' + currentUser.user.lastName}
             </h1>
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <h1 className="text-center">Color</h1>
+            <h1 className="font-bold text-center">{currentUser.user.color}</h1>
           </div>
           <div className="flex flex-col gap-y-2">
             <h1 className="text-center">Role</h1>

--- a/hackportal.config.ts
+++ b/hackportal.config.ts
@@ -492,6 +492,7 @@ export type statRecordTypes = {
   hackathonExperience: Record<number, number>;
   heardFrom: Record<string, number>;
   timestamp: Record<string, number>;
+  color: Record<string, number>;
 };
 
 //add the title for each field that will be displayed as chart titles in admin stats page

--- a/hackportal.config.ts
+++ b/hackportal.config.ts
@@ -4,6 +4,7 @@ export const hackPortalConfig: HackPortalConfig = {
   //  which hold all the questions of that type
   //add extra questions types(even ones already used) to question topics and add more questions under each question type
   //questions are displayed on page in order
+  teamColor: ['Red', 'Green', 'Blue', 'Yellow'],
   registrationFields: {
     //Question Topic
     generalQuestions: [
@@ -541,6 +542,7 @@ export interface HackPortalConfig {
     sponsorInfoQuestions: QuestionTypes[];
     oneLastThing: QuestionTypes[];
   };
+  teamColor: string[];
 }
 
 interface QuestionTypes {

--- a/hackportal.config.ts
+++ b/hackportal.config.ts
@@ -513,6 +513,7 @@ export const fieldNames = {
   scans: 'Swags', //not part of registration questions, used for scanner
   dietary: 'Dietary',
   timestamp: 'Registration Time',
+  color: 'Team Color Distribution',
 };
 
 //name fields that are checkbox questions belong here

--- a/lib/stats/color.ts
+++ b/lib/stats/color.ts
@@ -1,0 +1,17 @@
+import { hackPortalConfig } from '../../hackportal.config';
+
+export function computeHash(userId: string): number {
+  const p = 61,
+    m = 1000000009;
+  let ans = 0,
+    curr = 1;
+  for (let c of userId) {
+    ans = (ans + ((c.charCodeAt(0) * curr) % m)) % m;
+    curr = (curr * p) % m;
+  }
+  return ans;
+}
+
+export function determineColorByTeamIdx(userHashValue: number) {
+  return hackPortalConfig.teamColor[userHashValue % hackPortalConfig.teamColor.length];
+}

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -76,6 +76,7 @@ type Registration = {
    * Basic biographical user data
    */
   user: {
+    color: string;
     id: string;
     permissions: UserPermission[];
     firstName: string;

--- a/pages/api/applications/index.tsx
+++ b/pages/api/applications/index.tsx
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { auth, firestore } from 'firebase-admin';
 import initializeApi from '../../../lib/admin/init';
 import { userIsAuthorized } from '../../../lib/authorization/check-authorization';
+import { computeHash, determineColorByTeamIdx } from '../../../lib/stats/color';
 
 initializeApi();
 
@@ -98,6 +99,12 @@ async function handlePostApplications(req: NextApiRequest, res: NextApiResponse)
       message: '',
     });
   }
+
+  body = {
+    ...body,
+    user: { ...body.user, color: determineColorByTeamIdx(computeHash(body.user.id)) },
+  };
+
   const snapshot = await db
     .collection(APPLICATIONS_COLLECTION)
     .where('user.id', '==', body.user.id)

--- a/pages/api/creid.ts
+++ b/pages/api/creid.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import initializeApi from '../../lib/admin/init';
 import { firestore } from 'firebase-admin';
+import { computeHash, determineColorByTeamIdx } from '../../lib/stats/color';
 
 initializeApi();
 const db = firestore();
@@ -13,13 +14,24 @@ async function handleGetRequest(req: NextApiRequest, res: NextApiResponse) {
   }
   const snapshot = await db.collection('/registrations').get();
   const users = [];
-  snapshot.forEach((doc) => {
+  snapshot.forEach(async (doc) => {
+    const docId = doc.id;
+    const docData = doc.data();
+
     users.push({
-      id: doc.data().id,
+      id: docData.id,
       user: {
-        firstName: doc.data().user.firstName,
-        lastName: doc.data().user.lastName,
-        permissions: doc.data().user.permissions,
+        firstName: docData.user.firstName,
+        lastName: docData.user.lastName,
+        permissions: docData.user.permissions,
+      },
+    });
+
+    await doc.ref.update({
+      ...docData,
+      user: {
+        ...docData.user,
+        color: determineColorByTeamIdx(computeHash(docId)),
       },
     });
   });

--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -20,27 +20,6 @@ async function getCheckInEventName() {
   return checkInEventName;
 }
 
-function computeHash(userId: string): number {
-  const p = 61,
-    m = 1000000009;
-  let ans = 0,
-    curr = 1;
-  for (let c of userId) {
-    ans = (ans + ((c.charCodeAt(0) * curr) % m)) % m;
-    curr = (curr * p) % m;
-  }
-  return ans;
-}
-
-function determineColorByTeamIdx(teamIdx: number) {
-  return {
-    0: 'red',
-    1: 'blue',
-    2: 'green',
-    3: 'yellow',
-  }[teamIdx];
-}
-
 async function getStatsData() {
   const checkInEventName = await getCheckInEventName();
   // const swagData: Record<string, number> = {};
@@ -66,7 +45,7 @@ async function getStatsData() {
     }
     generalStats.timestamp[stringDate]++;
 
-    const userTeam = determineColorByTeamIdx(computeHash(doc.id) % 4);
+    const userTeam = doc.data().user.color;
     if (!generalStats.color.hasOwnProperty(userTeam)) {
       generalStats.color[userTeam] = 0;
     }

--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -20,6 +20,27 @@ async function getCheckInEventName() {
   return checkInEventName;
 }
 
+function computeHash(userId: string): number {
+  const p = 61,
+    m = 1000000009;
+  let ans = 0,
+    curr = 1;
+  for (let c of userId) {
+    ans = (ans + ((c.charCodeAt(0) * curr) % m)) % m;
+    curr = (curr * p) % m;
+  }
+  return ans;
+}
+
+function determineColorByTeamIdx(teamIdx: number) {
+  return {
+    0: 'red',
+    1: 'blue',
+    2: 'green',
+    3: 'yellow',
+  }[teamIdx];
+}
+
 async function getStatsData() {
   const checkInEventName = await getCheckInEventName();
   // const swagData: Record<string, number> = {};
@@ -30,6 +51,7 @@ async function getStatsData() {
     adminCount: 0,
     scans: {},
     timestamp: {},
+    color: {},
     ...statRecords,
   };
 
@@ -43,6 +65,12 @@ async function getStatsData() {
       generalStats.timestamp[stringDate] = 0;
     }
     generalStats.timestamp[stringDate]++;
+
+    const userTeam = determineColorByTeamIdx(computeHash(doc.id) % 4);
+    if (!generalStats.color.hasOwnProperty(userTeam)) {
+      generalStats.color[userTeam] = 0;
+    }
+    generalStats.color[userTeam]++;
 
     for (let arrayField of arrayFields) {
       if (!userData[arrayField]) continue;

--- a/pages/dashboard/scan-in.tsx
+++ b/pages/dashboard/scan-in.tsx
@@ -14,7 +14,7 @@ import Sidebar from './Components/Sidebar';
  */
 export default function Scan() {
   const router = useRouter();
-  const { user, isSignedIn, hasProfile } = useAuthContext();
+  const { user, isSignedIn, hasProfile, profile } = useAuthContext();
   const [qrData, setQRData] = useState('');
   const [qrLoading, setQRLoading] = useState(false);
   const [error, setError] = useState('');
@@ -79,6 +79,7 @@ export default function Scan() {
             >
               Fetch QR
             </div>
+            <div className="text-xl my-3">Your color: {profile.user.color}</div>
             <QRCode data={qrData} loading={qrLoading} width={300} height={300} />
           </div>
         ) : (

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -86,7 +86,7 @@ export default function ProfilePage() {
                     <h1 className="font-bold">{profile.studyLevel}</h1>
                   </div>
                   <div className="profile-view-color flex flex-col gap-y-2">
-                    <div className="font-bold text-xl">Team Color</div>
+                    <div className="font-bold text-xl">Your Color</div>
                     <h1 className="font-bold">{profile.user.color}</h1>
                   </div>
                 </div>

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -85,6 +85,10 @@ export default function ProfilePage() {
                     <div className="font-bold text-xl">Level of Study</div>
                     <h1 className="font-bold">{profile.studyLevel}</h1>
                   </div>
+                  <div className="profile-view-color flex flex-col gap-y-2">
+                    <div className="font-bold text-xl">Team Color</div>
+                    <h1 className="font-bold">{profile.user.color}</h1>
+                  </div>
                 </div>
               </div>
             </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -45,9 +45,13 @@ a.link {
   display: grid;
   grid-template-areas:
     'name role'
-    'university university';
+    'university color';
   row-gap: 2rem;
   column-gap: 1rem;
+}
+
+.profile-view-color {
+  grid-area: color;
 }
 
 .profile-view-name {


### PR DESCRIPTION
Added a temporary algorithm that will determine which color group a user belongs to based on their ID. Currently, I haven't added the color into user doc because we might need to change some hashing parameters that are used to determine which group user belongs to later on as more people signs up. Currently, the color distribution can be found in Stats at a Glance dashboard. 