### PR TITLE
feat: Change schedule event card Page text to hyperlink

### DIFF
--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -329,7 +329,16 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
                     {<Backpack style={{ fontSize: 'medium', margin: '2px' }} />}
                     Page
                   </p>
-                  <p>{eventData.page}</p>
+                  {eventData.page && (
+                    <a
+                      href={eventData.page}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="italic hover:underline font-medium"
+                    >
+                      Notion Page
+                    </a>
+                  )}
                 </div>
               </div>
 


### PR DESCRIPTION
Included a hyperlink under the page section in the schedule event card so users can get directed to the notion page straight from schedule. The link would just be the link to the notion page for the corresponding workshop.